### PR TITLE
Simplifications & fix for issue #1

### DIFF
--- a/index.js
+++ b/index.js
@@ -340,6 +340,7 @@ export function generx(f,recursed) {
         enumerable:false,
         value: () => 
           {
+			length = Infinity;
           	realized = [];
 			({ generator, next } =  makeGenerator(...arguments));
 			return generator;

--- a/index.js
+++ b/index.js
@@ -333,7 +333,10 @@ export function generx(f,recursed) {
 				realized = [],
 				{ generator, next } = makeGenerator(...arguments);
 			// bounce to `next`, which can be overwritten to replace the current generator
-			generator.next = (value) => next(value);
+			Object.defineProperty(generator,"next", {
+				enumerable:false,
+				value: (value) => next(value),
+			});
       // define reset to use the original arguments to create
       // a new generator and assign it to the generator variable
       Object.defineProperty(generator,"reset",{
@@ -450,7 +453,7 @@ export function generx(f,recursed) {
 					},
 					ownKeys(target) {
 						target.realize();
-						return Object.keys(target).concat("count","length","proxy","realized","reset");
+						return Object.keys(target).concat("count","length","next","proxy","realized","reset");
 					},
 					set(target,property,value) {
 						const i = parseInt(property);

--- a/test/index.js
+++ b/test/index.js
@@ -152,6 +152,16 @@ describe("sync",function() {
 		chai.expect(a1).eql(a2);
 		done();
 	});
+	it("reset should restore array access after spread & array access",function(done) {
+		const a1 = testarray,
+			  g1 = synchronous();
+		// realize the sequence, which consumes the values & sets length
+		[...g1];
+		g1[0];
+		g1.reset();
+		chai.expect(a1[0]).equal(g1[0]);
+		done();
+	});
 	it("reverse",function(done) {
 		const a1 = testarray.reverse(),
 			a2 = synchronous().reverse();
@@ -282,6 +292,15 @@ describe("async",function() {
 			a2.push(a);
 		}
 		chai.expect(a1).eql(a2);
+	});
+	it("reset should restore array access after iteration & array access",async function() {
+		const a1 = testarray,
+			  g1 = asynchronous();
+		// go through the sequence
+		for await (let a of g1) {}
+		await g1[0];
+		await g1.reset();
+		chai.expect(a1[0]).equal(await g1[0]);
 	});
 	it("reverse",async function() {
 		const a1 = testarray.reverse(),

--- a/test/index.js
+++ b/test/index.js
@@ -111,7 +111,7 @@ describe("sync",function() {
 		done();
 	});
 	it("keys",function(done) {
-		chai.expect(Object.keys(synchronous()).length).equal(Object.keys(testarray).length+1); // for "reset"
+		chai.expect(Object.keys(synchronous())).eql(Object.keys(testarray));
 		done();
 	});
 	it("lastIndexOf",function(done) {

--- a/test/index.js
+++ b/test/index.js
@@ -143,6 +143,15 @@ describe("sync",function() {
 		chai.expect(r1).equal(r2);
 		done();
 	});
+	it("reset",function(done) {
+		const a1 = testarray,
+			  g2 = synchronous();
+		let a2 = [...g2];
+		g2.reset();
+		a2 = [...g2];
+		chai.expect(a1).eql(a2);
+		done();
+	});
 	it("reverse",function(done) {
 		const a1 = testarray.reverse(),
 			a2 = synchronous().reverse();
@@ -262,6 +271,17 @@ describe("async",function() {
 		const r1 = testarray.reduce((accum,i) => accum += i,0),
 			r2 = await asynchronous().reduce((accum,i) => accum += i,0);
 		chai.expect(r1).equal(r2);
+	});
+	it("reset",async function() {
+		const a1 = testarray,
+			  g2 = asynchronous();
+		let a2 = [];
+		for await (let a of g2) {}
+		g2.reset();
+		for await (let a of g2) {
+			a2.push(a);
+		}
+		chai.expect(a1).eql(a2);
 	});
 	it("reverse",async function() {
 		const a1 = testarray.reverse(),


### PR DESCRIPTION
There are three commits in this pull request:

1. Simplified proxied `next()` of resettable generator (and added `value` parameter, as per the spec).
2. Fix for issue #1.
3. Made `next()` of resettable generator non-enumerable.

The changes include tests.