### PR TITLE
Internal changes

### DIFF
--- a/index.js
+++ b/index.js
@@ -337,18 +337,17 @@ export function generx(f,recursed) {
 				enumerable:false,
 				value: (value) => next(value),
 			});
-      // define reset to use the original arguments to create
-      // a new generator and assign it to the generator variable
-      Object.defineProperty(generator,"reset",{
-        enumerable:false,
-        value: () => 
-          {
-			length = Infinity;
-          	realized = [];
-			({ generator, next } =  makeGenerator(...arguments));
-			return generator;
-          }
-      });
+			// define reset to use the original arguments to create
+			// a new generator and assign it to the generator variable
+			Object.defineProperty(generator,"reset",{
+				enumerable:false,
+				value: () => {
+					length = Infinity;
+					realized = [];
+					({ generator, next } = makeGenerator(...arguments));
+					return generator;
+				},
+			});
 			const proxy = new Proxy(generator,{
 					deleteProperty(target,property) {
 						delete target[property];
@@ -389,7 +388,7 @@ export function generx(f,recursed) {
 												delete target[j];
 												delete target[j+1];
 											} else {
-											  // do not try to omptize by moving this up, results can legitimately contain undefined
+											  // do not try to optimize by moving this up, results can legitimately contain undefined
 												target[j] = realized[j] = item.value;
 											}
 											return item.value;
@@ -437,7 +436,7 @@ export function generx(f,recursed) {
 										}
 										length = realized.length;
 									} else {
-										// do not try to omptize by moving this up, results can legitimately contain undefined
+										// do not try to optimize by moving this up, results can legitimately contain undefined
 										target[realized.length] = realized[realized.length] = value;
 										next = generator.next();
 									}
@@ -489,6 +488,6 @@ export function generx(f,recursed) {
 		Object.defineProperty(generator,"proxy",{value:proxy});
 		Object.defineProperty(generator,"realized",{get() { return realized.slice(); },set() { throw new Error("'realized' is read-only");}});
 		return proxy;
-		}
+		},
 	});
 }


### PR DESCRIPTION
## Overview

These commits change only internals, not external behavior, with an eye towards making iteration & array access more compatible.

## Details

Iterating over a generx generator and accessing elements as an array don't play well together. Before that can be looked into, however, I've reorganized some of the code in the resettable generator proxy. The main changes are about encapsulation (the state of the resettable generator is moved from local variables to a state object) and abstraction to reduce repetition (2 duplicate code blocks from the proxy's array access handler have been refactored into a function).

None of these changes result in changes to testable behavior, so no new tests are added. Existing tests still pass.